### PR TITLE
Fix bug - Carrefour collector, wait for cloudflare first

### DIFF
--- a/src/collectors/carrefour/carrefour.ts
+++ b/src/collectors/carrefour/carrefour.ts
@@ -34,12 +34,12 @@ export class CarrefourCollector extends ScrapperCollector {
     }
 
     async login(driver: Driver, params: any): Promise<string | void> {
+        // Wait for captcha to be successful
+        await driver.waitForCloudflareTurnstile()
+
         // Input email and password
         await driver.input_text(CarrefourSelectors.FIELD_EMAIL, params.id);
         await driver.input_text(CarrefourSelectors.FIELD_PASSWORD, params.password);
-
-        // Wait for captcha to be successful
-        await driver.waitForCloudflareTurnstile()
 
         // Click on submit button
         await driver.left_click(CarrefourSelectors.BUTTON_SUBMIT);

--- a/src/collectors/carrefour/carrefour.ts
+++ b/src/collectors/carrefour/carrefour.ts
@@ -10,7 +10,7 @@ export class CarrefourCollector extends ScrapperCollector {
     static CONFIG = {
         name: "Carrefour",
         description: "i18n.collectors.carrefour.description",
-        version: "3",
+        version: "4",
         website: "https://www.carrefour.fr",
         logo: "https://upload.wikimedia.org/wikipedia/fr/3/3b/Logo_Carrefour.svg",
         params: {


### PR DESCRIPTION
Carrefour collector sometimes fail to input full email in the field. This occurs when the captcha resolution occurs at the same time the email is typed in the field. When the cloudflare token is added to the DOM, the selected input field is focused out preventing the full email completion.