### PR TITLE
Constrain proxy to geolocation

### DIFF
--- a/src/collectors/scrapperCollector.ts
+++ b/src/collectors/scrapperCollector.ts
@@ -45,7 +45,7 @@ export abstract class ScrapperCollector extends AbstractCollector {
 
     async _collect(state: State, secret: Secret, location: Location | null, twofa_promise: TwofaPromise): Promise<Invoice[]> {
         // Get proxy
-        const proxy = this.config.useProxy ? ProxyFactory.getProxy().get(location) : null;
+        const proxy = this.config.useProxy ? await ProxyFactory.getProxy().get(location) : null;
 
         // Start browser and page
         this.driver = new Driver(this);

--- a/src/driver/puppeteer/browser.ts
+++ b/src/driver/puppeteer/browser.ts
@@ -2,6 +2,7 @@ import puppeteer, { Browser, ConnectOptions } from "rebrowser-puppeteer-core";
 import * as ChromeLauncher from 'chrome-launcher';
 import { pageController, PageWithCursor } from "./pageController";
 import { ChromeFactory } from "../chrome/chromeFactory";
+import { Proxy } from "../../proxy/abstractProxy";
 
 let Xvfb;
 try {
@@ -19,19 +20,12 @@ export interface Options {
   args?: string[];
   headless?: boolean;
   customConfig?: ChromeLauncher.Options;
-  proxy?: ProxyOptions;
+  proxy?: Proxy;
   turnstile?: boolean;
   connectOption?: ConnectOptions;
   disableXvfb?: boolean;
   ignoreAllFlags?: boolean;
   remoteChrome?: boolean;
-}
-
-export interface ProxyOptions {
-  host: string;
-  port: number;
-  username?: string;
-  password?: string;
 }
 
 export async function connect({

--- a/src/driver/puppeteer/pageController.ts
+++ b/src/driver/puppeteer/pageController.ts
@@ -2,13 +2,7 @@ import { createCursor, GhostCursor } from 'ghost-cursor';
 import { Browser, Page } from "rebrowser-puppeteer-core";
 import { AbstractChrome } from "../chrome/abstractChrome";
 import { checkTurnstile } from './turnstile';
-import { ProxyOptions } from './browser';
-
-function getRandomInt(min, max) {
-    min = Math.ceil(min);
-    max = Math.floor(max);
-    return Math.floor(Math.random() * (max - min + 1)) + min;
-}
+import { Proxy } from '../../proxy/abstractProxy';
 
 export interface PageWithCursor extends Page {
   realClick: GhostCursor["click"];
@@ -18,7 +12,7 @@ export interface PageWithCursor extends Page {
 export interface PageControllerOptions {
     browser: Browser,
     page: any,
-    proxy?: ProxyOptions,
+    proxy?: Proxy,
     turnstile: boolean,
     xvfbsession: any,
     killProcess: boolean,
@@ -60,7 +54,10 @@ export async function pageController({
 
     turnstileSolver()
 
-    if (proxy && proxy.username && proxy.password) await page.authenticate({ username: proxy.username, password: proxy.password });
+    if (proxy && proxy.username && proxy.password){
+        await page.setExtraHTTPHeaders(proxy.headers);
+        await page.authenticate({ username: proxy.username, password: proxy.password });
+    }
 
     await page.evaluateOnNewDocument(() => {
         Object.defineProperty(MouseEvent.prototype, 'screenX', {

--- a/src/driver/puppeteer/pageController.ts
+++ b/src/driver/puppeteer/pageController.ts
@@ -54,9 +54,7 @@ export async function pageController({
 
     turnstileSolver()
 
-    if (proxy && proxy.username && proxy.password){
-        await page.authenticate({ username: proxy.username, password: proxy.password });
-    }
+    if (proxy && proxy.username && proxy.password) await page.authenticate({ username: proxy.username, password: proxy.password });
 
     await page.evaluateOnNewDocument(() => {
         Object.defineProperty(MouseEvent.prototype, 'screenX', {

--- a/src/driver/puppeteer/pageController.ts
+++ b/src/driver/puppeteer/pageController.ts
@@ -11,7 +11,7 @@ export interface PageWithCursor extends Page {
 
 export interface PageControllerOptions {
     browser: Browser,
-    page: any,
+    page: Page,
     proxy?: Proxy,
     turnstile: boolean,
     xvfbsession: any,
@@ -55,7 +55,6 @@ export async function pageController({
     turnstileSolver()
 
     if (proxy && proxy.username && proxy.password){
-        await page.setExtraHTTPHeaders(proxy.headers);
         await page.authenticate({ username: proxy.username, password: proxy.password });
     }
 
@@ -75,8 +74,8 @@ export async function pageController({
     });
 
     const cursor = createCursor(page);
-    page.realCursor = cursor;
-    page.realClick = cursor.click;
-
-    return page;
+    const pageWithCursor = page as PageWithCursor;
+    pageWithCursor.realCursor = cursor;
+    pageWithCursor.realClick = cursor.click;
+    return pageWithCursor;
 }

--- a/src/proxy/abstractProxy.ts
+++ b/src/proxy/abstractProxy.ts
@@ -3,7 +3,8 @@ export type Proxy = {
     host: string,
     port: number,
     username?: string,
-    password?: string
+    password?: string,
+    headers: any
 }
 
 export type Location = {

--- a/src/proxy/abstractProxy.ts
+++ b/src/proxy/abstractProxy.ts
@@ -3,8 +3,7 @@ export type Proxy = {
     host: string,
     port: number,
     username?: string,
-    password?: string,
-    headers: any
+    password?: string
 }
 
 export type Location = {
@@ -21,7 +20,7 @@ export abstract class AbstractProxy {
         lon: '2.348993'
     }
 
-    abstract get(location: Location | null): Proxy | null;
+    abstract get(location: Location | null): Promise<Proxy | null>;
 
     async locate(ip: string | string[] | undefined): Promise<Location | null> {
         // Check if ip is an array

--- a/src/proxy/noProxy.ts
+++ b/src/proxy/noProxy.ts
@@ -1,7 +1,7 @@
 import { AbstractProxy, Location, Proxy } from "./abstractProxy";
 
 export class NoProxy extends AbstractProxy {
-    get(location: Location | null): Proxy | null {
+    async get(location: Location | null): Promise<Proxy | null> {
         return null;
     }
 }

--- a/src/proxy/oxylabProxy.ts
+++ b/src/proxy/oxylabProxy.ts
@@ -48,18 +48,16 @@ export class OxylabProxy extends AbstractProxy {
     async geoConstraint(proxy: Proxy, location: Location): Promise<void> {
         for (const radius of OxylabProxy.RADIUS_ACCURACIES) {
             try {
-                const a = await axios.get(OxylabProxy.LOCATION_URL, {
+                await axios.get(OxylabProxy.LOCATION_URL, {
                     httpsAgent: new HttpsProxyAgent(proxy.uri, {
                         headers: {
                             "X-Oxylabs-Geolocation": `${location.lat}:${location.lon};${radius}`
                         }
                     })
                 });
-                console.log(a.data);
                 return;
             } catch (error) {
                 // Nothing to do, just try the next radius
-                console.log(`Radius ${radius} failed`);
             }
         }
         // If we reach here, it means that all radius attempts failed

--- a/src/proxy/oxylabProxy.ts
+++ b/src/proxy/oxylabProxy.ts
@@ -34,7 +34,7 @@ export class OxylabProxy extends AbstractProxy {
             username: `customer-${this.username}-cc-${location.country}-sessid-${sessid}`,
             password: this.password
         };
-        await this.geoConstraint(proxy, location);
+        await this.geoConstrain(proxy, location);
         return proxy;
     }
 
@@ -45,7 +45,7 @@ export class OxylabProxy extends AbstractProxy {
      * @param proxy - The proxy configuration object containing the URI to be tested.
      * @throws {Error} Throws an error with a cause if the proxy cannot be constrained to the specified coordinates.
      */
-    async geoConstraint(proxy: Proxy, location: Location): Promise<void> {
+    async geoConstrain(proxy: Proxy, location: Location): Promise<void> {
         for (const radius of OxylabProxy.RADIUS_ACCURACIES) {
             try {
                 await axios.get(OxylabProxy.LOCATION_URL, {

--- a/src/proxy/oxylabProxy.ts
+++ b/src/proxy/oxylabProxy.ts
@@ -3,7 +3,7 @@ import * as utils from "../utils";
 
 export class OxylabProxy extends AbstractProxy {
 
-    static RADIUS_ACCURACIES = [10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000]
+    static RADIUS_ACCURACY = 10; // in miles
 
     username: string;
     password: string;
@@ -25,7 +25,10 @@ export class OxylabProxy extends AbstractProxy {
             host: "pr.oxylabs.io",
             port: 7777,
             username: `customer-${this.username}-cc-${location.country}`,
-            password: this.password
+            password: this.password,
+            headers: {
+                "X-Oxylabs-Geolocation": `${location.lat}:${location.lon};${OxylabProxy.RADIUS_ACCURACY}`
+            }
         };
     }
 }

--- a/src/proxy/oxylabProxy.ts
+++ b/src/proxy/oxylabProxy.ts
@@ -1,9 +1,15 @@
 import { AbstractProxy, Proxy, Location } from "./abstractProxy";
 import * as utils from "../utils";
+import axios from "axios";
+import { HttpsProxyAgent } from 'https-proxy-agent';
 
 export class OxylabProxy extends AbstractProxy {
 
-    static RADIUS_ACCURACY = 10; // in miles
+    static OXYLAB_HOST = "pr.oxylabs.io";
+    static OXYLAB_PORT = 7777;
+
+    static RADIUS_ACCURACY = 5; // in miles
+    static LOCATION_URL = "https://ip.oxylabs.io/location";
 
     username: string;
     password: string;
@@ -14,21 +20,43 @@ export class OxylabProxy extends AbstractProxy {
         this.password = utils.getEnvVar("PROXY_OXYLAB_PASSWORD");
     }
 
-    get(location: Location | null): Proxy | null {
+    async get(location: Location | null): Promise<Proxy | null> {
         if(location == null) {
             console.log("Location is unknown, using default location");
             location = AbstractProxy.DEFAULT_LOCATION
         }
 
-        return {
-            uri: `http://customer-${this.username}-cc-${location.country}:${this.password}@pr.oxylabs.io:7777`,
-            host: "pr.oxylabs.io",
-            port: 7777,
-            username: `customer-${this.username}-cc-${location.country}`,
-            password: this.password,
-            headers: {
-                "X-Oxylabs-Geolocation": `${location.lat}:${location.lon};${OxylabProxy.RADIUS_ACCURACY}`
-            }
+        const sessid = new Date().getTime().toString();
+        const proxy: Proxy = {
+            uri: `http://customer-${this.username}-cc-${location.country}-sessid-${sessid}:${this.password}@${OxylabProxy.OXYLAB_HOST}:${OxylabProxy.OXYLAB_PORT}`,
+            host: OxylabProxy.OXYLAB_HOST,
+            port: OxylabProxy.OXYLAB_PORT,
+            username: `customer-${this.username}-cc-${location.country}-sessid-${sessid}`,
+            password: this.password
         };
+        await this.geoConstraint(proxy, location);
+        return proxy;
+    }
+
+    /**
+     * Ensures that the provided proxy can be constrained to specific coordinates
+     * by making a test request to a predefined location URL.
+     *
+     * @param proxy - The proxy configuration object containing the URI to be tested.
+     * @throws {Error} Throws an error with a cause if the proxy cannot be constrained to the specified coordinates.
+     */
+    async geoConstraint(proxy: Proxy, location: Location): Promise<void> {
+
+        try {
+            await axios.get(OxylabProxy.LOCATION_URL, {
+                httpsAgent: new HttpsProxyAgent(proxy.uri, {
+                    headers: {
+                        "X-Oxylabs-Geolocation": `${location.lat}:${location.lon};${OxylabProxy.RADIUS_ACCURACY}`
+                    }
+                })
+            });
+        } catch (error) {
+            throw new Error("Cannot constraint proxy to coordinates", { cause: error });
+        }
     }
 }

--- a/src/proxy/oxylabProxy.ts
+++ b/src/proxy/oxylabProxy.ts
@@ -8,7 +8,7 @@ export class OxylabProxy extends AbstractProxy {
     static OXYLAB_HOST = "pr.oxylabs.io";
     static OXYLAB_PORT = 7777;
 
-    static RADIUS_ACCURACIES = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 200, 500, 1000, 2000]; // in miles
+    static RADIUS_ACCURACIES = [1, 2, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 200, 500, 1000, 2000]; // in miles
     static LOCATION_URL = "https://ip.oxylabs.io/location";
 
     username: string;

--- a/src/registryServer.ts
+++ b/src/registryServer.ts
@@ -30,8 +30,8 @@ export class RegistryServer {
             console.log("Pong! Invoice-Collector server successfully reached");
         })
         .catch(error => {
-            console.error(`Could not reach Invoice-Collector server at ${error.request.res?.responseUrl || error.request._currentUrl}. Status code: ${error.response?.status || error.code}\n
-                You are still able to use the product but some features may not work as expected.`);
+            console.error(`Could not reach Invoice-Collector server at ${error.request.res?.responseUrl || error.request._currentUrl}. Status code: ${error.response?.status || error.code}
+You are still able to use the product but some features may not work as expected.`);
         });
     }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,8 +20,6 @@ import { I18n } from './i18n';
 export class Server {
 
     static OAUTH_TOKEN_VALIDITY_DURATION_MS = Number(utils.getEnvVar("OAUTH_TOKEN_VALIDITY_DURATION_MS"));
-    static LOCALES = ['en', 'fr'];
-    static DEFAULT_LOCALE = 'en';
 
     tokens: object;
     secret_manager: AbstractSecretManager;
@@ -73,8 +71,8 @@ export class Server {
         }
 
         //Check if locale is supported
-        if(locale && !Server.LOCALES.includes(locale)) {
-            throw new StatusError(`Locale "${locale}" not supported. Available locales are: ${Server.LOCALES.join(", ")}.`, 400);
+        if(locale && !I18n.LOCALES.includes(locale)) {
+            throw new StatusError(`Locale "${locale}" not supported. Available locales are: ${I18n.LOCALES.join(", ")}.`, 400);
         }
 
         // Get user from remote_id
@@ -485,12 +483,12 @@ export class Server {
         //Check if locale field is missing
         if(!locale || typeof locale !== 'string') {
             //Set default locale
-            locale = Server.DEFAULT_LOCALE;
+            locale = I18n.DEFAULT_LOCALE;
         }
 
         //Check if locale is supported
-        if(locale && !Server.LOCALES.includes(locale)) {
-            throw new StatusError(`Locale "${locale}" not supported. Available locales are: ${Server.LOCALES.join(", ")}.`, 400);
+        if(locale && !I18n.LOCALES.includes(locale)) {
+            throw new StatusError(`Locale "${locale}" not supported. Available locales are: ${I18n.LOCALES.join(", ")}.`, 400);
         }
 
         return CollectorLoader.getAll().map((collector): Config => {

--- a/test/auto.spec.ts
+++ b/test/auto.spec.ts
@@ -2,11 +2,11 @@ import dotenv from 'dotenv';
 dotenv.config();
 import { expect, describe } from '@jest/globals';
 import { CollectorLoader } from '../src/collectors/collectorLoader';
-import { Server } from '../src/server';
 import { AuthenticationError } from '../src/error';
 import { ScrapperCollector } from '../src/collectors/scrapperCollector';
 import { Secret } from '../src/secret_manager/abstractSecretManager';
 import { Collect } from '../src/collect/collect';
+import { State } from '../src/model/credential';
 
 const ids = process.argv.slice(3);
 const ONE_MINUTE = 60 * 1000; // 1 minute in milliseconds
@@ -37,8 +37,11 @@ for (const collector of CollectorLoader.getAll()) {
                     },
                     cookies: null,
                 };
+
+                // Collect invoices
                 const collect = new Collect("")
-                await expect(collect.collect_new_invoices(collector, secret, true, [], null))
+                collect.state = State.DEFAULT_STATE;
+                await expect(collect.collect_new_invoices(collect.state, collector, secret, true, [], null))
                     .rejects.toThrow(AuthenticationError);
             }, ONE_MINUTE);
 
@@ -50,8 +53,11 @@ for (const collector of CollectorLoader.getAll()) {
                     },
                     cookies: null,
                 };
+
+                // Collect invoices
                 const collect = new Collect("")
-                await expect(collect.collect_new_invoices(collector, secret, true, [], null))
+                collect.state = State.DEFAULT_STATE;
+                await expect(collect.collect_new_invoices(collect.state, collector, secret, true, [], null))
                     .rejects.toThrow(AuthenticationError);
             }, ONE_MINUTE);
 

--- a/test/manual.ts
+++ b/test/manual.ts
@@ -71,7 +71,7 @@ import { I18n } from '../src/i18n';
             collect.twofa_promise.setCode(twofa_code);
         });
 
-        const newInvoices = await collect.collect_new_invoices(collect.state, collector, secret, true, [], {country: "FR", lat: '', lon: ''});
+        const newInvoices = await collect.collect_new_invoices(collect.state, collector, secret, true, [], null);
         console.log(`${newInvoices.length} invoices downloaded`);
 
         for (const invoice of newInvoices) {

--- a/test/manual.ts
+++ b/test/manual.ts
@@ -3,7 +3,6 @@ const prompt = promptSync({});
 import dotenv from 'dotenv';
 dotenv.config();
 import fs from 'fs';
-import { Server } from "../src/server";
 import { CollectorLoader } from '../src/collectors/collectorLoader';
 import { LoggableError } from '../src/error';
 import { Secret } from '../src/secret_manager/abstractSecretManager';
@@ -87,7 +86,7 @@ import { I18n } from '../src/i18n';
         }
     } catch (error) {
         if (error instanceof Error) {
-            error.message = I18n.get(error.message, Server.DEFAULT_LOCALE);
+            error.message = I18n.get(error.message, I18n.DEFAULT_LOCALE);
         }
         console.error(error);
         if (error instanceof LoggableError) {

--- a/views/ui/script.js
+++ b/views/ui/script.js
@@ -62,9 +62,6 @@ async function showCredentials() {
     // Get the elements
     const credentialsList = document.getElementById('credentials-list');
 
-    // Reset values
-    credentialsList.innerHTML = '';
-
     // Hide other containers
     document.getElementById('credentials-container').hidden = false;
     document.getElementById('companies-container').hidden = true;
@@ -75,6 +72,9 @@ async function showCredentials() {
     // Get the credentials
     const response = await fetch(`credentials?token=${token}`);
     const credentials = await response.json();
+
+    // Reset values
+    credentialsList.innerHTML = '';
 
     credentials.forEach(credential => {
         const credentialItem = document.createElement('div');


### PR DESCRIPTION
- Make a first request to oxylab with proxy header and session to constrain IP to coordinates
- Use this session to reuse the same IP with the browser
- Remove `LOCALES` and `DEFAULT_LOCALE` from Server
- Fix UI bug