### PR TITLE
Close #104 - All endpoints now work with Bearer token instead of query token

### DIFF
--- a/src/database/abstractDatabase.ts
+++ b/src/database/abstractDatabase.ts
@@ -32,7 +32,9 @@ export abstract class AbstractDatabase {
     abstract getUser(user_id: string): Promise<User|null>;
 
     abstract getUserFromCustomerIdAndRemoteId(customer_id: string, remote_id: string): Promise<User|null>;
-    
+
+    abstract getUserBellongingToCustomer(user_id: string, customer_id: string): Promise<User|null>;
+
     abstract createUser(user: User): Promise<User>;
 
     abstract updateUser(user: User): Promise<void>;

--- a/src/database/mongodb.ts
+++ b/src/database/mongodb.ts
@@ -209,6 +209,28 @@ export class MongoDB extends AbstractDatabase {
         return user;
     }
 
+    async getUserBellongingToCustomer(user_id: string, customer_id: string): Promise<User|null> {
+        if (!this.db) {
+            throw new Error("Database is not connected");
+        }
+        const document = await this.db.collection(MongoDB.USER_COLLECTION).findOne({
+            _id: new ObjectId(user_id),
+            customer_id: new ObjectId(customer_id)
+        });
+        if (!document) {
+            return null;
+        }
+        let user = new User(
+            document.customer_id.toString(),
+            document.remote_id,
+            document.location,
+            document.locale,
+            document.termsConditions
+        );
+        user.id = document._id.toString();
+        return user;
+    }
+
     async createUser(user: User): Promise<User> {
         if (!this.db) {
             throw new Error("Database is not connected");

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,7 @@ app.post('/api/v1/authorize', async (req, res) => {
     try {
         // Perform authorization
         console.log('POST authorize');
-        const response = await server.post_authorize(req.headers.authorization, req.body.remote_id, req.body.locale, req.body.email);
+        const response = await server.post_user(req.headers.authorization, req.body.remote_id, req.body.locale, req.body.email);
 
         // Build response
         res.setHeader('Content-Type', 'application/json');
@@ -172,7 +172,7 @@ app.post('/api/v1/user', async (req, res) => {
     try {
         // Perform authorization
         console.log('POST user');
-        const response = await server.post_authorize(req.headers.authorization, req.body.remote_id, req.body.locale, req.body.email);
+        const response = await server.post_user(req.headers.authorization, req.body.remote_id, req.body.locale, req.body.email);
 
         // Build response
         res.setHeader('Content-Type', 'application/json');

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,10 +54,11 @@ function handle_error(e, req, res){
 // ---------- GENERAL ENDPOINTS ----------
 
 // BEARER AUTHENTICATION
+//TODO DEPRECATED : REMOVE
 app.post('/api/v1/authorize', async (req, res) => {
     try {
         // Perform authorization
-        console.log('POST authorize');
+        console.warn('POST authorize (DEPRECATED)');
         const response = await server.post_user(req.headers.authorization, req.body.remote_id, req.body.locale, req.body.email);
 
         // Build response

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,12 +97,12 @@ app.get('/api/v1/test_callback', async (req, res) => {
     }
 });
 
-// TOKEN AUTHENTICATION
+// BEARER OR TOKEN AUTHENTICATION
 app.post('/api/v1/feedback', async (req, res) => {
     try {
         // Send feedback
         console.log('POST feedback');
-        await server.post_feedback(req.query.token, req.body.type, req.body.message, req.body.email);
+        await server.post_feedback(req.headers.authorization, req.query.token, req.body.type, req.body.message, req.body.email);
 
         // Build response
         res.end()
@@ -183,12 +183,12 @@ app.delete('/api/v1/user', async (req, res) => {
 
 // ---------- CREDENTIAL ENDPOINTS ----------
 
-// TOKEN AUTHENTICATION
-app.get('/api/v1/credentials', async (req, res) => {
+// BEARER AUTHENTICATION
+app.get('/api/v1/user/:user_id/credentials', async (req, res) => {
     try {
         // Get credentials
         console.log(`GET credentials`);
-        const credentials = await server.get_credentials(req.query.token)
+        const credentials = await server.get_credentials(req.headers.authorization, req.params.user_id, undefined);
 
         // Build response
         res.setHeader('Content-Type', 'application/json');
@@ -199,11 +199,41 @@ app.get('/api/v1/credentials', async (req, res) => {
 });
 
 // TOKEN AUTHENTICATION
+app.get('/api/v1/credentials', async (req, res) => {
+    try {
+        // Get credentials
+        console.log(`GET credentials`);
+        const credentials = await server.get_credentials(undefined, undefined, req.query.token)
+
+        // Build response
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify(credentials));
+    } catch (e) {
+        handle_error(e, req, res);
+    }
+});
+
+// BEARER AUTHENTICATION
+app.post('/api/v1/user/:user_id/credential', async (req, res) => {
+    try {
+        // Save credential
+        console.log(`POST credential`);
+        const response = await server.post_credential(req.headers.authorization, req.params.user_id, undefined, req.body.collector, req.body.params, req.headers['x-user-ip']);
+
+        // Build response
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify(response));
+    } catch (e) {
+        handle_error(e, req, res);
+    }
+});
+
+// TOKEN AUTHENTICATION
 app.post('/api/v1/credential', async (req, res) => {
     try {
         // Save credential
         console.log(`POST credential`);
-        const response = await server.post_credential(req.query.token, req.body.collector, req.body.params, req.headers['x-user-ip']);
+        const response = await server.post_credential(undefined, undefined, req.query.token, req.body.collector, req.body.params, req.headers['x-user-ip']);
 
         // Build response
         res.setHeader('Content-Type', 'application/json');
@@ -213,11 +243,11 @@ app.post('/api/v1/credential', async (req, res) => {
     }
 });
 
-// TOKEN AUTHENTICATION
-app.get('/api/v1/credential/:id', async (req, res) => {
+// BEARER AUTHENTICATION
+app.get('/api/v1/user/:user_id/credential/:credential_id', async (req, res) => {
     try {
         // Get credential status
-        const response = await server.get_credential(req.query.token, req.params.id);
+        const response = await server.get_credential(req.headers.authorization, req.params.user_id, undefined, req.params.credential_id);
 
         // Build response
         res.setHeader('Content-Type', 'application/json');
@@ -228,11 +258,25 @@ app.get('/api/v1/credential/:id', async (req, res) => {
 });
 
 // TOKEN AUTHENTICATION
-app.delete('/api/v1/credential/:id', async (req, res) => {
+app.get('/api/v1/credential/:credential_id', async (req, res) => {
+    try {
+        // Get credential status
+        const response = await server.get_credential(undefined, undefined, req.query.token, req.params.credential_id);
+
+        // Build response
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify(response));
+    } catch (e) {
+        handle_error(e, req, res);
+    }
+});
+
+// BEARER AUTHENTICATION
+app.delete('/api/v1/user/:user_id/credential/:credential_id', async (req, res) => {
     try {
         // Delete credential
-        console.log(`DELETE credential ${req.params.id}`);
-        await server.delete_credential(req.query.token, req.params.id);
+        console.log(`DELETE credential ${req.params.credential_id}`);
+        await server.delete_credential(req.headers.authorization, req.params.user_id, undefined, req.params.credential_id);
 
         // Build response
         res.end()
@@ -242,11 +286,11 @@ app.delete('/api/v1/credential/:id', async (req, res) => {
 });
 
 // TOKEN AUTHENTICATION
-app.post('/api/v1/credential/:id/2fa', async (req, res) => {
+app.delete('/api/v1/credential/:credential_id', async (req, res) => {
     try {
-        // Post 2fa
-        console.log(`POST 2fa ${req.params.id}`);
-        await server.post_credential_2fa(req.query.token, req.params.id, req.body.code);
+        // Delete credential
+        console.log(`DELETE credential ${req.params.credential_id}`);
+        await server.delete_credential(undefined, undefined, req.query.token, req.params.credential_id);
 
         // Build response
         res.end()
@@ -256,11 +300,53 @@ app.post('/api/v1/credential/:id/2fa', async (req, res) => {
 });
 
 // BEARER AUTHENTICATION
-app.post('/api/v1/credential/:id/collect', async (req, res) => {
+app.post('/api/v1/user/:user_id/credential/:credential_id/2fa', async (req, res) => {
+    try {
+        // Post 2fa
+        console.log(`POST 2fa ${req.params.credential_id}`);
+        await server.post_credential_2fa(req.headers.authorization, req.params.user_id, undefined, req.params.credential_id, req.body.code);
+
+        // Build response
+        res.end()
+    } catch (e) {
+        handle_error(e, req, res);
+    }
+});
+
+// TOKEN AUTHENTICATION
+app.post('/api/v1/credential/:credential_id/2fa', async (req, res) => {
+    try {
+        // Post 2fa
+        console.log(`POST 2fa ${req.params.credential_id}`);
+        await server.post_credential_2fa(undefined, undefined, req.query.token, req.params.credential_id, req.body.code);
+
+        // Build response
+        res.end()
+    } catch (e) {
+        handle_error(e, req, res);
+    }
+});
+
+// BEARER AUTHENTICATION
+app.post('/api/v1/user/:user_id/credential/:credential_id/collect', async (req, res) => {
     try {
         // Post collect
-        console.log(`POST collect ${req.params.id}`);
-        await server.post_credential_collect(req.query.token, req.params.id);
+        console.log(`POST collect ${req.params.credential_id}`);
+        await server.post_credential_collect(req.headers.authorization, req.params.user_id, undefined, req.params.credential_id);
+
+        // Build response
+        res.end()
+    } catch (e) {
+        handle_error(e, req, res);
+    }
+});
+
+// TOKEN AUTHENTICATION
+app.post('/api/v1/credential/:credential_id/collect', async (req, res) => {
+    try {
+        // Post collect
+        console.log(`POST collect ${req.params.credential_id}`);
+        await server.post_credential_collect(undefined, undefined, req.query.token, req.params.credential_id);
 
         // Build response
         res.end()
@@ -271,12 +357,12 @@ app.post('/api/v1/credential/:id/collect', async (req, res) => {
 
 // ---------- COLLECTOR ENDPOINTS ----------
 
-// BEARER AUTHENTICATION
+// BEARER OR TOKEN AUTHENTICATION
 app.get('/api/v1/collectors', async (req, res) => {
     try {
         // List all collectors
         console.log(`GET collectors`);
-        const response = await server.get_collectors(req.query.token, req.query.locale);
+        const response = await server.get_collectors(req.headers.authorization, req.query.token, req.query.locale);
 
         // Build response
         res.setHeader('Content-Type', 'application/json');

--- a/src/index.ts
+++ b/src/index.ts
@@ -168,11 +168,26 @@ app.get('/api/v1/users', async (req, res) => {
 });
 
 // BEARER AUTHENTICATION
-app.delete('/api/v1/user', async (req, res) => {
+app.post('/api/v1/user', async (req, res) => {
+    try {
+        // Perform authorization
+        console.log('POST user');
+        const response = await server.post_authorize(req.headers.authorization, req.body.remote_id, req.body.locale, req.body.email);
+
+        // Build response
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify(response));
+    } catch (e) {
+        handle_error(e, req, res);
+    }
+});
+
+// BEARER AUTHENTICATION
+app.delete('/api/v1/user/:user_id', async (req, res) => {
     try {
         // Delete user
         console.log('DELETE user');
-        await server.delete_user(req.headers.authorization, req.body.remote_id);
+        await server.delete_user(req.headers.authorization, req.params.user_id);
 
         // Build response
         res.end()

--- a/src/model/customer.ts
+++ b/src/model/customer.ts
@@ -82,6 +82,10 @@ export class Customer {
         return await DatabaseFactory.getDatabase().getUsers(this.id);
     }
 
+    async getUser(user_id: string) {
+        return await DatabaseFactory.getDatabase().getUserBellongingToCustomer(user_id, this.id);
+    }
+
     setTheme(theme: string) {
         //Check if theme is supported
         if(!Object.values(Theme).includes(theme as Theme)) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -52,7 +52,10 @@ export class Server {
         remote_id: string | undefined,
         locale: string | undefined,
         email: string | undefined
-    ): Promise<{token: string}> {
+    ): Promise<{
+        token: string,
+        id: string
+    }> {
         // Get customer from bearer
         const customer = await Customer.fromBearer(bearer);
 
@@ -136,7 +139,10 @@ export class Server {
             console.log(`Token ${token} deleted`);
         }, Server.OAUTH_TOKEN_VALIDITY_DURATION_MS);
 
-        return { token }
+        return {
+            token,
+            id: user.id
+        }
     }
 
     // TOKEN AUTHENTICATION
@@ -305,21 +311,21 @@ export class Server {
     }
 
     // BEARER AUTHENTICATION
-    public async delete_user(bearer: string | undefined, remote_id: string | undefined) {
+    public async delete_user(bearer: string | undefined, user_id: string) {
         // Get customer from bearer
         const customer = await Customer.fromBearer(bearer);
 
-        //Check if remote_id field is missing
-        if(!remote_id) {
-            throw new MissingField("remote_id");
+        //Check if user_id field is missing
+        if(!user_id) {
+            throw new MissingField("user_id");
         }
 
-        // Get user from remote_id
-        const user = await customer.getUserFromRemoteId(remote_id);
+        // Get user from user_id
+        const user = await customer.getUser(user_id);
 
         // Check if user exists
         if (!user) {
-            throw new StatusError(`User with remote_id "${remote_id}" not found.`, 400);
+            throw new StatusError(`User with id "${user_id}" not found.`, 400);
         }
 
         // Delete user and all its credentials


### PR DESCRIPTION
- The following endpoints now work with Bearer token:
  - `GET /credentials`
  - `POST /credential`
  - `GET /credential`
  - `POST /credential`
  - `GET /collectors`
  - `POST /feedback`
- Deprecate `POST /authorize` to replace it with `POST /user`
- Deprecate `DELETE /user` to replace it with `DELETE /user/{id}`
- Return full user for `POST /user`
- Return full credential for `POST /credential`