### PR TITLE
Endpoint `GET /test/callback` can now send a notification disconnected to callback

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,11 +85,11 @@ app.get('/api/v1/ui', async (req, res) => {
 });
 
 // BEARER AUTHENTICATION
-app.get('/api/v1/test_callback', async (req, res) => {
+app.get('/api/v1/test_callback/:type', async (req, res) => {
     try {
         // Test callback
         console.log('GET test_callback');
-        await server.get_test_callback(req.headers.authorization);
+        await server.get_test_callback(req.headers.authorization, req.params.type);
 
         // Build response
         res.end()

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,7 @@ app.get('/api/v1/ui', async (req, res) => {
 });
 
 // BEARER AUTHENTICATION
-app.get('/api/v1/test_callback/:type', async (req, res) => {
+app.get('/api/v1/test/callback/:type', async (req, res) => {
     try {
         // Test callback
         console.log('GET test_callback');

--- a/src/index.ts
+++ b/src/index.ts
@@ -157,21 +157,6 @@ app.post('/api/v1/reset', async (req, res) => {
     }
 });
 
-//BEARER AUTHENTICATION
-app.post('/api/v1/bearer', async (req, res) => {
-    try {
-        // Generate bearer
-        console.log('POST bearer');
-        const response = await server.post_bearer(req.headers.authorization);
-
-        // Build response
-        res.setHeader('Content-Type', 'application/json');
-        res.end(JSON.stringify(response));
-    } catch (e) {
-        handle_error(e, req, res);
-    }
-});
-
 // ---------- CUSTOMER ENDPOINTS ----------
 
 // BEARER AUTHENTICATION
@@ -214,7 +199,7 @@ app.post('/api/v1/customer', async (req, res) => {
 
 app.post('/api/v1/customer/bearer', async (req, res) => {
     try {
-        // Generate customer bearer
+        // Generate a new bearer for customer
         console.log(`POST customer bearer`);
         const response = await server.post_customer_bearer(req.headers.authorization);
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -75,24 +75,35 @@ export class Server {
     }
 
     // BEARER AUTHENTICATION
-    public async get_test_callback(bearer: string | undefined): Promise<void> {
+    public async get_test_callback(bearer: string | undefined, type: string): Promise<void> {
         // Get customer from bearer
         const customer = await this.getCustomerFromBearer(bearer);
 
-        // Get users from customer
-        const users = await customer.getUsers();
-
-        // Get fake invoice datas
-        let {collector_id, remote_id, invoice} = utils.createFakeInvoice();
-
-        // Get remote_id from first user if exists
-        if(users.length > 0) {
-            remote_id = users[0].remote_id;
+        // Check if type field is missing
+        if(!type) {
+            throw new MissingField("type");
         }
 
-        // Send invoice to callback
+        // Create callback handler
         const callback = new CallbackHandler(customer);
-        await callback.sendInvoice(collector_id, remote_id, invoice);
+
+        // If type is "invoice", send a fake invoice
+        if(type === "invoice") {
+            // Get fake invoice datas
+            let {collector_id, remote_id, invoice} = utils.createFakeInvoice();
+
+            // Send fake invoice to callback
+            await callback.sendInvoice(collector_id, remote_id, invoice);
+        }
+        else if(type === "notification_disconnected") {
+            // Get fake notification disconnected
+            let {collector_id, credential_id, user_id, remote_id } = utils.createFakeNotificationDisconnected();
+            // Send notification disconnected
+            await callback.sendNotificationDisconnected(collector_id, credential_id, user_id, remote_id);
+        }
+        else {
+            throw new StatusError(`Type "${type}" not supported.`, 400);
+        }
     }
 
     // TOKEN AUTHENTICATION

--- a/src/server.ts
+++ b/src/server.ts
@@ -250,31 +250,6 @@ export class Server {
         delete this.resetTokens[resetToken];
     }
 
-    // BEARER AUTHENTICATION
-    public async post_bearer(
-        bearer: string | undefined
-    ): Promise<{
-        bearer: string
-    }> {
-        // Get customer from bearer
-        const customer = await this.getCustomerFromBearer(bearer);
-
-        // Generate new bearer token
-        const newBearer = utils.generate_bearer();
-
-        // Compute hashed bearer
-        const hashedBearer = utils.hash_string(newBearer);
-
-        // Update customer bearer
-        customer.bearer = hashedBearer;
-
-        // Commit changes in database
-        await customer.commit();
-
-        // Return new bearer token
-        return { bearer: newBearer };
-    }
-
     // ---------- CUSTOMER ENDPOINTS ----------
 
     // BEARER AUTHENTICATION

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -113,7 +113,21 @@ export function createFakeInvoice(): { collector_id: string, remote_id: string, 
     };
     return {
         collector_id: "sliced_invoices",
-        remote_id: "fake_remote_id",
+        remote_id: "R121439",
         invoice
     }
+}
+
+export function createFakeNotificationDisconnected(): {
+        collector_id: string,
+        credential_id: string,
+        user_id: string,
+        remote_id: string
+    } {
+    return {
+        collector_id: "sliced_invoices",
+        credential_id: "6776b5258821de266afbc3f6",
+        user_id: "687108e5dce5050bc8ca53c1",
+        remote_id: "R121439",
+    };
 }


### PR DESCRIPTION
- Rename endpoint `GET /test_callback` to `GET /test/callback`
- Endpoint now takes a query paraeter `type` to define the type of payload to send to the callback
- Remove endpoint `POST /bearer` duplicate of `POST /customer/bearer`