### PR TITLE
Fix `amazon_business` selector to match

### DIFF
--- a/test/manual.ts
+++ b/test/manual.ts
@@ -156,7 +156,7 @@ function getHashFromSecret(secret: Secret): string {
         const newInvoices = await collect.collect_new_invoices(collect.state, collector, secret, true, [], null);
         console.log(`${newInvoices.length} invoices downloaded`);
 
-        // ---------- PART 4 : SAVE AND CHECK INVOICES ----------
+        // ---------- PART 4 : SAVE INVOICES ----------
 
         for (const invoice of newInvoices) {
             // If data is not null
@@ -176,7 +176,11 @@ function getHashFromSecret(secret: Secret): string {
                 timestamp: invoice.timestamp,
                 mimetype: invoice.mimetype
             })
+        }
 
+        // ---------- PART 5 : CHECK INVOICES ----------
+
+        for (const invoice of newInvoices) {
             assert(invoice.id.length > 0, `Invoice id is empty`);
             assert(invoice.timestamp > 0, `Timestamp ${invoice.timestamp} is not greater than 0`);
             assert(!isNaN(invoice.timestamp), `Timestamp ${invoice.timestamp} is NaN`);


### PR DESCRIPTION
```
<a class="a-link-normal" href="/gp/digital/your-account/order-summary.html/ref=oh_aui_ajax_dpi?ie=UTF8&amp;orderID=D01-7131456-9631060&amp;print=1">
            Récapitulatif de commande
</a>
```
and
```
<a class="a-link-normal" href="/gp/css/summary/print.html/ref=oh_aui_ajax_invoice?ie=UTF8&amp;orderID=405-0867354-7153143">
            Récapitulatif de commande
</a>
```