### PR TITLE
Do not raise error when adding sketch collector

### DIFF
--- a/src/collectors/sketchCollector.ts
+++ b/src/collectors/sketchCollector.ts
@@ -1,5 +1,5 @@
 import { AbstractCollector, Invoice, CompleteInvoice, CollectorType, CollectorState, CollectorCaptcha } from "./abstractCollector";
-import { CollectorError } from '../error';
+import { UnfinishedCollectorError } from '../error';
 import { Location } from "../proxy/abstractProxy";
 import { Secret } from "../secret_manager/abstractSecretManager";
 import { TwofaPromise } from "../collect/twofaPromise";
@@ -36,10 +36,10 @@ export abstract class SketchCollector extends AbstractCollector {
     }
 
     async _collect(state: State, secret: Secret, location: Location | null, twofa_promise: TwofaPromise): Promise<Invoice[]> {
-        return [];
+        throw new UnfinishedCollectorError(this);
     }
 
     async _download(invoice: Invoice): Promise<CompleteInvoice> {
-        throw new CollectorError("SketchCollector does not support downloading invoices", this);
+        throw new UnfinishedCollectorError(this);
     }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -682,7 +682,6 @@ export class Server {
                 customer.email,
                 user.id
             );
-            throw new StatusError(`The collector ${collector.config.id} is not implemented yet. We have been notified of your request and will try to implement it as soon as possible.`, 400);
         }
 
         // Check if customer can add more credentials


### PR DESCRIPTION
- Do not raise error when adding sketch collector
- Collect will occur and raise an `UnfinishedCollectorError`
- This allow us to collect credentials to implement collector