### PR TITLE
Improve `amazon` and `amazon_collector`

### DIFF
--- a/src/collect/collect.ts
+++ b/src/collect/collect.ts
@@ -111,7 +111,7 @@ export class Collect {
             }
 
             // Log success
-            RegistryServer.getInstance().logSuccess(collector.config.id);
+            RegistryServer.getInstance().logSuccess(collector);
 
             // Update last collect
             credential.last_collect_timestamp = Date.now();

--- a/src/collectors/core/amazon/amazon.ts
+++ b/src/collectors/core/amazon/amazon.ts
@@ -163,22 +163,20 @@ export class AmazonCollector extends WebCollector {
 
         // Get orders
         const orders = await Promise.all(
-            orderElements
-                .map(async (order) => {
-                    const id = await order.getAttribute(AmazonSelectors.CONTAINER_ORDER_ID, "textContent");
-                    const amount = await order.getAttribute(AmazonSelectors.CONTAINER_ORDER_AMOUNT, "textContent");
-                    const date = await order.getAttribute(AmazonSelectors.CONTAINER_ORDER_DATE, "textContent");
-                    const link = driver.origin() + await order.getAttribute(AmazonSelectors.CONTAINER_DOCUMENTS_LINK, "href");
-                    const timestamp = timestampFromString(date, 'd MMMM yyyy', language);
+            orderElements.map(async (order) => {
+                const id = await order.getAttribute(AmazonSelectors.CONTAINER_ORDER_ID, "textContent");
+                const amount = await order.getAttribute(AmazonSelectors.CONTAINER_ORDER_AMOUNT, "textContent");
+                const date = await order.getAttribute(AmazonSelectors.CONTAINER_ORDER_DATE, "textContent");
+                const link = driver.origin() + await order.getAttribute(AmazonSelectors.CONTAINER_DOCUMENTS_LINK, "href");
+                const timestamp = timestampFromString(date, 'd MMMM yyyy', language);
 
-                    return {
-                        id,
-                        timestamp,
-                        amount,
-                        link
-                    };
-                }
-            )
+                return {
+                    id,
+                    timestamp,
+                    amount,
+                    link
+                };
+            })
         );
 
         // Return orders older than 2 days

--- a/src/registryServer.ts
+++ b/src/registryServer.ts
@@ -3,6 +3,7 @@ import { fullStackTrace, LoggableError } from './error'
 import * as utils from './utils'
 import { TermsConditions } from './model/user';
 import { Server } from './server';
+import { AbstractCollector } from './collectors/abstractCollector';
 
 export class RegistryServer {
 
@@ -44,9 +45,10 @@ You are still able to use the product but some features may not work as expected
         });
     }
 
-    logSuccess(collector: string) {
+    logSuccess(collector: AbstractCollector) {
         this.client.post("/log/success", {
-            collector
+            collector: collector.config.id,
+            version: collector.config.version,
         })
         .then(response => {
             console.log("Invoice-Collector server successfully reached");


### PR DESCRIPTION
- `amazon` and `amazon_business`: Ignore orders younger than 2 days. Orders need to be older than 2 days before invoices are available
- Add field `version` to log success