### PR TITLE
Fix RegistryServer.logSuccess when registry-server does not exist.

### DIFF
--- a/src/registryServer.ts
+++ b/src/registryServer.ts
@@ -54,7 +54,7 @@ You are still able to use the product but some features may not work as expected
             console.log("Invoice-Collector server successfully reached");
         })
         .catch(error => {
-            console.error(`Could not reach Invoice-Collector server at ${error.request.res.responseUrl}. Status code: ${error.response.status}`);
+            console.error(`Could not reach Invoice-Collector server at ${error.request.res?.responseUrl || error.request._currentUrl}. Status code: ${error.response?.status || error.code}`);
         });
     }
 


### PR DESCRIPTION
When REGISTRY_SERVER_ENDPOINT does not contain a valid DN, error is not catch correctly in logSuccess.