### PR TITLE
Update logo

### DIFF
--- a/src/collectors/core/leroy_merlin/leroy_merlin.ts
+++ b/src/collectors/core/leroy_merlin/leroy_merlin.ts
@@ -11,9 +11,9 @@ export class LeroyMerlinCollector extends WebCollector {
         id: "leroy_merlin",
         name: "Leroy Merlin",
         description: "i18n.collectors.leroy_merlin.description",
-        version: "11",
+        version: "12",
         website: "https://www.leroymerlin.fr",
-        logo: "https://upload.wikimedia.org/wikipedia/commons/d/d4/Leroy_Merlin.svg",
+        logo: "https://upload.wikimedia.org/wikipedia/commons/a/a4/Leroy_Merlin_-_logo_%28France%2C_1995-%29.svg",
         type: CollectorType.WEB,
         params: {
             id: {

--- a/src/collectors/sketch/bouygues_telecom/bouygues_telecom.ts
+++ b/src/collectors/sketch/bouygues_telecom/bouygues_telecom.ts
@@ -8,9 +8,9 @@ export class BouyguesTelecomCollector extends SketchCollector {
         id: "bouygues_telecom",
         name: "Bouygues Telecom",
         description: "i18n.collectors.bouygues_telecom.description",
-        version: "0",
+        version: "1",
         website: "https://www.bouyguestelecom.fr/mon-compte/mes-factures",
-        logo: "https://portal-ui-images.s3.eu-central-1.amazonaws.com/logo/120x120/9042.jpg",
+        logo: "https://upload.wikimedia.org/wikipedia/commons/f/f8/Bouygues_Telecom_201x_logo.svg",
         type: CollectorType.SKETCH,
         params: {
             email: {

--- a/src/collectors/sketch/castorama/castorama.ts
+++ b/src/collectors/sketch/castorama/castorama.ts
@@ -7,9 +7,9 @@ export class CastoramaCollector extends SketchCollector {
         id: "castorama",
         name: "Castorama",
         description: "i18n.collectors.castorama.description",
-        version: "0",
+        version: "1",
         website: "https://castorama.fr",
-        logo: "https://upload.wikimedia.org/wikipedia/commons/f/f0/Castorama_Logo.svg",
+        logo: "https://upload.wikimedia.org/wikipedia/commons/8/89/Castorama_-_logo_%28France%2C_2014-%29.svg",
         type: CollectorType.SKETCH,
         params: {
             email: {

--- a/src/collectors/sketch/chronopost_preuve_de_livraison/chronopost_preuve_de_livraison.ts
+++ b/src/collectors/sketch/chronopost_preuve_de_livraison/chronopost_preuve_de_livraison.ts
@@ -8,9 +8,9 @@ export class ChronopostPreuveDeLivraisonCollector extends SketchCollector {
         id: "chronopost_preuve_de_livraison",
         name: "Chronopost - Preuve de livraison",
         description: "i18n.collectors.chronopost_preuve_de_livraison.description",
-        version: "0",
+        version: "1",
         website: "https://www.chronopost.fr/fr/aide/faq/livraison-de-vos-envois/comment-obtenir-la-preuve-de-livraison-de-mon-colis",
-        logo: "https://portal-ui-images.s3.eu-central-1.amazonaws.com/logo/120x120/105806.jpg",
+        logo: "https://upload.wikimedia.org/wikipedia/fr/d/d0/Chronopost-logo.svg",
         type: CollectorType.SKETCH,
         params: {
             email: {

--- a/src/collectors/sketch/decathlon/decathlon.ts
+++ b/src/collectors/sketch/decathlon/decathlon.ts
@@ -8,9 +8,9 @@ export class DecathlonCollector extends SketchCollector {
         id: "decathlon",
         name: "DECATHLON",
         description: "i18n.collectors.decathlon.description",
-        version: "0",
+        version: "1",
         website: "https://www.decathlon.de/login",
-        logo: "https://portal-ui-images.s3.eu-central-1.amazonaws.com/logo/120x120/27571.jpg",
+        logo: "https://fr.m.wikipedia.org/wiki/Fichier:Decathlon_-_logo_%28France,_2024%29.svg",
         type: CollectorType.SKETCH,
         params: {
             email: {

--- a/src/collectors/sketch/decathlon_factures_carte_fidelite/decathlon_factures_carte_fidelite.ts
+++ b/src/collectors/sketch/decathlon_factures_carte_fidelite/decathlon_factures_carte_fidelite.ts
@@ -8,9 +8,9 @@ export class DecathlonFacturesCarteFideliteCollector extends SketchCollector {
         id: "decathlon_factures_carte_fidelite",
         name: "Decathlon (Factures carte fidelite)",
         description: "i18n.collectors.decathlon_factures_carte_fidelite.description",
-        version: "0",
+        version: "1",
         website: "https://www.decathlon.fr/fr/loginPage",
-        logo: "https://portal-ui-images.s3.eu-central-1.amazonaws.com/logo/120x120/118382.jpg",
+        logo: "https://fr.m.wikipedia.org/wiki/Fichier:Decathlon_-_logo_%28France,_2024%29.svg",
         type: CollectorType.SKETCH,
         params: {
             email: {

--- a/src/collectors/sketch/easyjet/easyjet.ts
+++ b/src/collectors/sketch/easyjet/easyjet.ts
@@ -8,9 +8,9 @@ export class EasyjetCollector extends SketchCollector {
         id: "easyjet",
         name: "easyJet",
         description: "i18n.collectors.easyjet.description",
-        version: "0",
+        version: "1",
         website: "https://www.easyjet.com/DE/secure/MyEasyJet.mvc/ViewBooking",
-        logo: "https://portal-ui-images.s3.eu-central-1.amazonaws.com/logo/120x120/1218.jpg",
+        logo: "https://upload.wikimedia.org/wikipedia/commons/1/1b/EasyJet_logo.svg",
         type: CollectorType.SKETCH,
         params: {
             email: {

--- a/src/collectors/sketch/manomano/manomano.ts
+++ b/src/collectors/sketch/manomano/manomano.ts
@@ -8,9 +8,9 @@ export class ManomanoCollector extends SketchCollector {
         id: "manomano",
         name: "ManoMano",
         description: "i18n.collectors.manomano.description",
-        version: "0",
+        version: "1",
         website: "https://www.manomano.fr/se-connecter",
-        logo: "https://portal-ui-images.s3.eu-central-1.amazonaws.com/logo/120x120/122300.jpg",
+        logo: "https://upload.wikimedia.org/wikipedia/commons/1/1c/ManoMano_2018.png",
         type: CollectorType.SKETCH,
         params: {
             email: {

--- a/src/collectors/sketch/rexel/rexel.ts
+++ b/src/collectors/sketch/rexel/rexel.ts
@@ -8,9 +8,9 @@ export class RexelCollector extends SketchCollector {
         id: "rexel",
         name: "Rexel",
         description: "i18n.collectors.rexel.description",
-        version: "0",
+        version: "1",
         website: "https://www.rexel.de/",
-        logo: "https://portal-ui-images.s3.eu-central-1.amazonaws.com/logo/120x120/163751.jpg",
+        logo: "https://upload.wikimedia.org/wikipedia/commons/9/90/Rexel_logo.svg",
         type: CollectorType.SKETCH,
         params: {
             email: {

--- a/src/collectors/sketch/shell_energy_europe/shell_energy_europe.ts
+++ b/src/collectors/sketch/shell_energy_europe/shell_energy_europe.ts
@@ -8,9 +8,9 @@ export class ShellEnergyEuropeCollector extends SketchCollector {
         id: "shell_energy_europe",
         name: "Shell Energy Europe",
         description: "i18n.collectors.shell_energy_europe.description",
-        version: "0",
+        version: "1",
         website: "https://energyeurope.shell.com/s/invoices",
-        logo: "https://portal-ui-images.s3.eu-central-1.amazonaws.com/logo/120x120/4420599.jpg",
+        logo: "https://cdn.worldvectorlogo.com/logos/shell-energy.svg",
         type: CollectorType.SKETCH,
         params: {
             email: {

--- a/src/collectors/sketch/vinci_autoroutes/vinci_autoroutes.ts
+++ b/src/collectors/sketch/vinci_autoroutes/vinci_autoroutes.ts
@@ -8,9 +8,9 @@ export class VinciAutoroutesCollector extends SketchCollector {
         id: "vinci_autoroutes",
         name: "VINCI Autoroutes",
         description: "i18n.collectors.vinci_autoroutes.description",
-        version: "0",
+        version: "1",
         website: "https://espaceabonnes.vinci-autoroutes.com",
-        logo: "https://portal-ui-images.s3.eu-central-1.amazonaws.com/logo/120x120/27509.jpg",
+        logo: "https://upload.wikimedia.org/wikipedia/fr/9/9c/Logo_Vinci-Autoroutes.svg",
         type: CollectorType.SKETCH,
         params: {
             email: {


### PR DESCRIPTION
Update logo for collectors:
- `leroy_merlin`
- `castorama`
- `bouygues_telecom`
- `manomano`
- `rexel`
- `shell_energy_europe`
- `vinci_autoroutes`
- `easyjet`
- `chronopost`