### PR TITLE
Optimise porxy usage

### DIFF
--- a/src/collectors/community/freemobile/freemobile.ts
+++ b/src/collectors/community/freemobile/freemobile.ts
@@ -33,7 +33,6 @@ export class FreeMobileCollector extends WebCollector {
         loginUrl: "https://mobile.free.fr/account/v2/login",
         entryUrl: "https://mobile.free.fr/account",
         captcha: CollectorCaptcha.NONE,
-        useProxy: false,
         enableInteractiveLogin: true
     }
 

--- a/src/collectors/core/free/free.ts
+++ b/src/collectors/core/free/free.ts
@@ -31,7 +31,6 @@ export class FreeCollector extends WebCollector {
         loginUrl: "https://subscribe.free.fr/login/",
         entryUrl: "https://adsl.free.fr/facture_liste.pl",
         captcha: CollectorCaptcha.NONE,
-        useProxy: false,
         enableInteractiveLogin: false
     }
 

--- a/src/collectors/core/intermarche/intermarche.ts
+++ b/src/collectors/core/intermarche/intermarche.ts
@@ -11,7 +11,7 @@ export class IntermarcheCollector extends WebCollector {
         id: "intermarche",
         name: "Intermarché",
         description: "i18n.collectors.intermarche.description",
-        version: "9",
+        version: "10",
         website: "https://www.intermarche.com",
         logo: "https://upload.wikimedia.org/wikipedia/commons/9/96/Intermarch%C3%A9_logo_2009_classic.svg",
         type: CollectorType.WEB,
@@ -29,7 +29,7 @@ export class IntermarcheCollector extends WebCollector {
                 mandatory: true,
             }
         },
-        loginUrl: "https://www.intermarche.com/",
+        loginUrl: "https://www.intermarche.com/connexion/itm",
         entryUrl: "https://www.intermarche.com/gestion-de-compte/mes-courses",
         captcha: CollectorCaptcha.DATADOME,
         enableInteractiveLogin: true,

--- a/src/collectors/core/intermarche/intermarche.ts
+++ b/src/collectors/core/intermarche/intermarche.ts
@@ -11,7 +11,7 @@ export class IntermarcheCollector extends WebCollector {
         id: "intermarche",
         name: "Intermarché",
         description: "i18n.collectors.intermarche.description",
-        version: "8",
+        version: "9",
         website: "https://www.intermarche.com",
         logo: "https://upload.wikimedia.org/wikipedia/commons/9/96/Intermarch%C3%A9_logo_2009_classic.svg",
         type: CollectorType.WEB,
@@ -84,7 +84,15 @@ export class IntermarcheCollector extends WebCollector {
     }
 
     async navigate(driver: Driver): Promise<void> {
+        // Close cookies banner if exists
         await driver.leftClick(IntermarcheSelectors.BUTTON_REFUSE_COOKIES, { raiseException: false, timeout: 5000});
+    }
+
+    async isEmpty(driver: Driver): Promise<boolean> {
+        // Wait for panel commandes to be loaded
+        await driver.getElement(IntermarcheSelectors.CONTAINER_PANEL_COMMANDES);
+        // Check if empty basket container exists
+        return await driver.getElement(IntermarcheSelectors.CONTAINER_EMPTY_BASKET, { raiseException: false, timeout: 100 }) != null;
     }
      
     async getInvoices(driver: Driver): Promise<Element[]> {

--- a/src/collectors/core/intermarche/intermarche.ts
+++ b/src/collectors/core/intermarche/intermarche.ts
@@ -11,7 +11,7 @@ export class IntermarcheCollector extends WebCollector {
         id: "intermarche",
         name: "Intermarché",
         description: "i18n.collectors.intermarche.description",
-        version: "10",
+        version: "9",
         website: "https://www.intermarche.com",
         logo: "https://upload.wikimedia.org/wikipedia/commons/9/96/Intermarch%C3%A9_logo_2009_classic.svg",
         type: CollectorType.WEB,

--- a/src/collectors/core/intermarche/selectors.ts
+++ b/src/collectors/core/intermarche/selectors.ts
@@ -51,4 +51,18 @@ export const IntermarcheSelectors = {
         selector: "#kc-login",
         info: "submit button"
     },
+
+    // NAVIGATE
+
+    CONTAINER_PANEL_COMMANDES: {
+        selector: "#panel-commandes >div:not(.loadableContent)",
+        info: "panel commandes container"
+    },
+
+    // IS EMPTY
+
+    CONTAINER_EMPTY_BASKET: {
+        selector: "#panel-commandes > div > div[data-testid='illustration-shopping-basket']",
+        info: "empty basket container"
+    }
 }

--- a/src/collectors/webCollector.ts
+++ b/src/collectors/webCollector.ts
@@ -12,10 +12,12 @@ import { WebSocketServer } from "../websocket/webSocketServer";
 import { MessageClick, MessageKeydown, MessageText } from "../websocket/message";
 import { KeyInput } from "rebrowser-puppeteer-core";
 import { CollectorMemory } from "../model/collectorMemory";
+import { Proxy } from '../proxy/abstractProxy';
 
 export type WebConfig = Config & {
     loginUrl: string,
     entryUrl?: string,
+    useProxyForLogin?: boolean,
     useProxy?: boolean,
     captcha: CollectorCaptcha,
     loadImages?: boolean,
@@ -42,7 +44,8 @@ export abstract class WebCollector extends V2Collector<WebConfig> {
         super({
             ...config,
             type: config.type || CollectorType.WEB,
-            useProxy: config.useProxy === undefined ? config.captcha !== CollectorCaptcha.NONE : config.useProxy,
+            useProxyForLogin: config.useProxy === undefined ? config.captcha !== CollectorCaptcha.NONE : config.useProxy,
+            useProxy: config.useProxy === undefined ? config.captcha == CollectorCaptcha.DATADOME : config.useProxy,
             state: config.state || CollectorState.ACTIVE,
             loadImages: config.loadImages === undefined ? false : config.loadImages,
             autoLogin: config.autoLogin || {
@@ -64,10 +67,13 @@ export abstract class WebCollector extends V2Collector<WebConfig> {
         useInteractiveLogin: boolean
     ): Promise<CompleteInvoice[]> {
         // Get proxy
-        const proxy = this.config.useProxy ? await ProxyFactory.getProxy().get(location) : null;
+        let proxy: Proxy | null = null;
+        if(this.config.useProxy) {
+            proxy = await ProxyFactory.getProxy().get(location);
+        }
 
         // Start browser and page
-        const driver = new Driver(this);
+        let driver = new Driver(this);
         this.driver = driver;
         await driver.open(proxy);
 
@@ -94,6 +100,24 @@ export abstract class WebCollector extends V2Collector<WebConfig> {
                     // Set progress step to logging in
                     state.update(State._2_LOGGING_IN);
                     webSocketServer?.sendState(State._2_LOGGING_IN);
+
+                    // If needs proxy for login
+                    if(this.config.useProxyForLogin && !proxy) {
+                        console.log('Open a new driver with proxy for login...');
+                        // Get proxy
+                        const proxy = await ProxyFactory.getProxy().get(location);
+                        // Open new driver with proxy
+                        driver = new Driver(this);
+                        await driver.open(proxy);
+                        // Transfer cookies, localStorage and url to new driver
+                        await driver.setCookies(await this.driver.getCookies([]));
+                        await driver.setLocalStorage(await this.driver.getLocalStorage([]));
+                        await driver.goto(this.driver.url());
+                        // Close old driver
+                        await this.driver.close();
+                        // Replace driver instance variable with new driver
+                        this.driver = driver;
+                    }
 
                     console.log("User is not logged in, logging in...");
 
@@ -150,6 +174,20 @@ export abstract class WebCollector extends V2Collector<WebConfig> {
                     let loadImagesPreviousValue = this.config.loadImages;
                     if(webSocketServer) {
                         this.config.loadImages = true;
+                    }
+
+                    // If needs proxy for login
+                    if(this.config.useProxyForLogin && !proxy) {
+                        console.log('Open a new driver with proxy for login...');
+                        // Get proxy
+                        const proxy = await ProxyFactory.getProxy().get(location);
+                        // Open new driver with proxy
+                        driver = new Driver(this);
+                        await driver.open(proxy);
+                        // Close old driver
+                        await this.driver.close();
+                        // Replace driver instance variable with new driver
+                        this.driver = driver;
                     }
 
                     // Go to login url

--- a/src/collectors/webCollector.ts
+++ b/src/collectors/webCollector.ts
@@ -44,7 +44,7 @@ export abstract class WebCollector extends V2Collector<WebConfig> {
             type: config.type || CollectorType.WEB,
             useProxy: config.useProxy === undefined ? config.captcha !== CollectorCaptcha.NONE : config.useProxy,
             state: config.state || CollectorState.ACTIVE,
-            loadImages: config.loadImages === undefined ? config.captcha == CollectorCaptcha.CLOUDFLARE : config.loadImages,
+            loadImages: config.loadImages === undefined ? false : config.loadImages,
             autoLogin: config.autoLogin || {
                 cookieNames: [],                // Take all cookies by default
                 localStorageKeys: undefined     // Take no localStorage by default
@@ -80,12 +80,6 @@ export abstract class WebCollector extends V2Collector<WebConfig> {
         try {
             // Pre actions
             await this.pre(driver);
-
-            // If web socket server exists, enable images
-            let loadImagesPreviousValue = this.config.loadImages;
-            if(webSocketServer) {
-                this.config.loadImages = true;
-            }
 
             // If no interactive login
             if(!useInteractiveLogin) {
@@ -152,6 +146,12 @@ export abstract class WebCollector extends V2Collector<WebConfig> {
 
                 // If first collect
                 if(webSocketServer) {
+                    // If web socket server exists, enable images
+                    let loadImagesPreviousValue = this.config.loadImages;
+                    if(webSocketServer) {
+                        this.config.loadImages = true;
+                    }
+
                     // Go to login url
                     await driver.goto(this.config.loginUrl, { navigation: false });
                     // Perform interactive login
@@ -176,6 +176,11 @@ export abstract class WebCollector extends V2Collector<WebConfig> {
                     }
                     else if (!this.config.entryUrl && collectorMemory.entryUrl) {
                         console.warn(`Collector ${this.config.id} has no entryUrl defined in config, but has one saved in memory. Consider defining it in the config.`);
+                    }
+
+                    // Restore previous load images value
+                    if(webSocketServer) {
+                        this.config.loadImages = loadImagesPreviousValue;
                     }
                 }
 
@@ -214,11 +219,6 @@ export abstract class WebCollector extends V2Collector<WebConfig> {
             await secret.setCookies(await driver.getCookies(this.config.autoLogin?.cookieNames));
             // Update secret.localStorage
             await secret.setLocalStorage(await driver.getLocalStorage(this.config.autoLogin?.localStorageKeys));
-
-            // Restore previous load images value
-            if(webSocketServer) {
-                this.config.loadImages = loadImagesPreviousValue;
-            }
 
             // Navigate to invoices
             await this.navigate(driver);

--- a/src/driver/driver.ts
+++ b/src/driver/driver.ts
@@ -95,7 +95,7 @@ export class Driver {
             await this.page.setRequestInterception(true);
             this.page.on("request", (request) => {
                 if (!request.isInterceptResolutionHandled()) {
-                    if (request.resourceType() === "image" && this.collector.config.loadImages === false) {
+                    if (request.resourceType() === "image" && this.collector.config.loadImages === false && !request.url().includes("cloudflare.com")) {
                         request.abort('aborted', 0);
                     } else {
                         request.continue(request.continueRequestOverrides(), 0);

--- a/src/proxy/oxylabProxy.ts
+++ b/src/proxy/oxylabProxy.ts
@@ -8,7 +8,7 @@ export class OxylabProxy extends AbstractProxy {
     static OXYLAB_HOST = "pr.oxylabs.io";
     static OXYLAB_PORT = 7777;
 
-    static RADIUS_ACCURACIES = [1, 2, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 200, 500, 1000, 2000]; // in miles
+    static RADIUS_ACCURACIES = [10, 100, 500, 1000, 2000]; // in miles
     static LOCATION_URL = "https://ip.oxylabs.io/location";
 
     username: string;


### PR DESCRIPTION
- Remove useless `proxy: false` for collectors `freemobile`, `free` and `bouygues_telecom`
- Improve collector `intermarche`, bump version
- Web collector can now don't use proxy for collect depending on captcha type
- Driver: do not abort cloudflare image requests
- Proxy: reduce radius list