### PR TITLE
Fix date parsing for 'yy' format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2179,11 +2179,11 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -65,7 +65,7 @@ export function timestampFromString(date: string, formats: string | string[], lo
         // For each format
         for (const format of formats) {
             // Try to parse date
-            let parsedDate = date_fns.parse(date.trim(), format, new Date(Date.UTC(1970, 0, 1)), { locale: dateFnsLocale });
+            let parsedDate = date_fns.parse(date.trim(), format, new Date(), { locale: dateFnsLocale });
 
             // Check if parsing succeeded
             if (!isNaN(parsedDate.getTime())) {


### PR DESCRIPTION
- Fix date parsing for 'yy' format, 26 was parsed to 1926 instead of 2026