### PR TITLE
Collect invoices again when `download_from_timestamp` is lowered

### DIFF
--- a/src/collectors/abstractCollector.ts
+++ b/src/collectors/abstractCollector.ts
@@ -154,6 +154,24 @@ export abstract class AbstractCollector<C extends Config> {
         return useInteractiveLogin;
     }
 
+    /**
+     * Returns the ids of the invoices that must not be collected again.
+     *
+     * An invoice that was only listed, never downloaded, has a null hash: it was
+     * older than the download from timestamp when the collect ran. Such an
+     * invoice stays collectable as soon as it falls back inside the window,
+     * otherwise lowering `download_from_timestamp` could never recover the
+     * history it is meant to open.
+     */
+    static getPreviousInvoiceIds(
+        previousInvoices: ModelInvoice[],
+        download_from_timestamp: number
+    ): string[] {
+        return previousInvoices
+            .filter((invoice) => invoice.hash !== null || invoice.timestamp < download_from_timestamp)
+            .map((invoice) => invoice.id);
+    }
+
     config: C;
 
     constructor(config: C) {

--- a/src/collectors/linearWebCollector.ts
+++ b/src/collectors/linearWebCollector.ts
@@ -1,4 +1,4 @@
-import { Invoice, CompleteInvoice } from "./abstractCollector";
+import { AbstractCollector, Invoice, CompleteInvoice } from "./abstractCollector";
 import { Driver, Element } from '../driver/driver';
 import { AuthenticationError, CollectorError, DisconnectedError, LoggableError, NoInvoiceFoundError } from '../error';
 import { ProxyFactory } from '../proxy/proxyFactory';
@@ -227,7 +227,7 @@ export abstract class LinearWebCollector extends WebCollector {
             await this.navigate(driver);
 
             // Get previous invoice ids
-            const previousInvoiceIds = previousInvoices.map((inv) => inv.id);
+            const previousInvoiceIds = AbstractCollector.getPreviousInvoiceIds(previousInvoices, download_from_timestamp);
 
             // For each page
             let invoices: CompleteInvoice[] = [];

--- a/src/collectors/v1Collector.ts
+++ b/src/collectors/v1Collector.ts
@@ -40,7 +40,7 @@ export abstract class V1Collector<C extends Config> extends AbstractCollector<C>
             );
 
             // Get previous invoice ids
-            const previousInvoiceIds = previousInvoices.map((inv) => inv.id);
+            const previousInvoiceIds = AbstractCollector.getPreviousInvoiceIds(previousInvoices, download_from_timestamp);
 
             // Get new invoices only
             const newInvoices = uniqueInvoices.filter((inv) => !previousInvoiceIds.includes(inv.id));

--- a/src/model/credential.ts
+++ b/src/model/credential.ts
@@ -149,12 +149,23 @@ export class Credential {
     }
 
     addInvoice(invoice: CompleteInvoice) {
-        this.invoices.push({
+        const record = {
             id: invoice.id,
             timestamp: invoice.timestamp,
             collected_timestamp: invoice.collected_timestamp,
             hash: invoice.hash
-        });
+        };
+
+        // An invoice that was listed but not downloaded is already recorded with
+        // a null hash. Replace it instead of pushing a duplicate when it is
+        // downloaded later on.
+        const index = this.invoices.findIndex((previous) => previous.id === record.id);
+        if (index !== -1) {
+            this.invoices[index] = record;
+        }
+        else {
+            this.invoices.push(record);
+        }
     }
 
     sortInvoices() {


### PR DESCRIPTION
## Problem

`download_from_timestamp` can only ever be raised. Lowering it has no effect, and the invoices it should open can never be collected.

An invoice older than the threshold is listed but not downloaded, and is still recorded on the credential (`collect.ts`, the branch that logs `Adding invoice ... to credential without sending to callback`). Because it is recorded, its id joins `previousInvoiceIds` on the next collect, and both `v1Collector` and `linearWebCollector` filter it out before the timestamp is ever considered. The invoice is excluded for good.

## Reproduction

1. Create a credential with `download_from_timestamp` set to today. The supplier exposes 358 invoices, all older, so none are downloaded but all 358 are recorded.
2. Lower `download_from_timestamp` to the beginning of the fiscal year.
3. Collect again. `v1Collector` logs `Found 358 invoices but none are new` and downloads nothing, forever.

Seen on `ovh`, but the logic is shared so every collector is affected.

## Fix

An invoice recorded without being downloaded is recognisable by its null `hash`. `AbstractCollector.getPreviousInvoiceIds()` now keeps such an invoice in the exclusion list only while it stays outside the download window, so widening the window makes it collectable again. Invoices that were actually downloaded keep a real hash and stay excluded for good, so nothing is downloaded twice.

`Credential.addInvoice()` now replaces the record sharing the same id instead of pushing a duplicate: an invoice first listed, then downloaded once the window is widened, would otherwise be recorded twice.

Behaviour of the exclusion list, given one invoice listed in January with a null hash and one downloaded in August:

| `download_from_timestamp` | excluded ids |
|---|---|
| August, the initial state | both |
| June | both |
| January | the August one only, so the January invoice is collected |

Nothing changes as long as the threshold is not lowered, so existing credentials keep behaving exactly as before.

## Testing

- `npx tsc --noEmit` passes.
- `npm run test.cicd.collectors` passes, 9072 collectors loaded.
- Exclusion list behaviour checked against the table above.

Happy to add a unit test if you want one, though I could not find an obvious home for pure logic tests in the current suite.
