### PR TITLE
Add `PUT /user/{userId}/credential/{credentialId}`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1308,6 +1308,103 @@ app.get('/api/v1/credential/:credential_id', async (req, res) => {
 /**
  * @openapi
  * /user/{userId}/credential/{credentialId}:
+ *   put:
+ *     tags: [Credential]
+ *     summary: Update credential (Bearer)
+ *     description: Updates a credential and starts collection. Only the provided fields are updated.
+ *     security:
+ *       - CustomerBearerAuth: []
+ *       - UserBearerAuth: []
+ *       - TokenAuth: []
+ *     parameters:
+ *       - name: userId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           $ref: "#/components/schemas/userId"
+ *       - name: credentialId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           $ref: "#/components/schemas/credentialId"
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               params:
+ *                 allOf:
+ *                   - $ref: "#/components/schemas/credentialParams"
+ *                 description: 'Replaces the stored parameters. _The cookies and the local storage are kept._'
+ *               download_from_timestamp:
+ *                 allOf:
+ *                   - $ref: "#/components/schemas/downloadFromTimestamp"
+ *                 description: 'Timestamp to start downloading invoices from in ms.'
+ *     responses:
+ *       200:
+ *         description: Success
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/credential'
+ *       400:
+ *         description: Bad request
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/error'
+ *       401:
+ *         description: Authentication error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/error'
+ *       403:
+ *         description: Credential does not belong to user
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/error'
+ *       409:
+ *         description: A collect is already in progress for this credential
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/error'
+ *       500:
+ *         description: Internal server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/error'
+ */
+// BEARER AUTHENTICATION
+app.put('/api/v1/user/:user_id/credential/:credential_id', async (req, res) => {
+    try {
+        // Update credential
+        console.log(`PUT /user/${req.params.user_id}/credential/${req.params.credential_id}`);
+        const response = await server.put_credential(
+            req.headers.authorization,
+            req.params.user_id,
+            req.query.token,
+            req.params.credential_id,
+            req.body.params,
+            req.body.download_from_timestamp
+        );
+
+        // Build response
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify(response));
+    } catch (e) {
+        handle_error(e, req, res);
+    }
+});
+
+/**
+ * @openapi
+ * /user/{userId}/credential/{credentialId}:
  *   delete:
  *     tags: [Credential]
  *     summary: Delete credential (Bearer)

--- a/src/server.ts
+++ b/src/server.ts
@@ -1218,6 +1218,138 @@ export class Server {
     }
 
     // TOKEN AUTHENTICATION
+    public async put_credential(
+        bearer: string | undefined,
+        user_id: string,
+        token: any,
+        id: string,
+        params: any | undefined,
+        download_from_timestamp: number | undefined
+    ): Promise<{
+        id: string,
+        user_id: string,
+        note: string,
+        create_timestamp: number,
+        download_from_timestamp: number,
+        last_collect_timestamp: number,
+        next_collect_timestamp: number,
+        invoices: any[],
+        state: State,
+        collector: Config,
+        wsPath: string
+    }> {
+        // Get user from bearer or token
+        const user = await this.getUserFromBearerOrToken(bearer, user_id, token);
+
+        // Get credential from id
+        const credential = await user.getCredential(id);
+
+        // Check if credential exists
+        if (!credential) {
+            throw new StatusError(`Credential with id "${id}" not found.`, 400);
+        }
+
+        // Check if credential belongs to user
+        if (credential.user_id != user.id) {
+            throw new StatusError(`Credential with id "${id}" does not belong to user.`, 403);
+        }
+
+        // Check if download_from_timestamp is valid
+        if(download_from_timestamp != undefined && (typeof download_from_timestamp !== "number" || download_from_timestamp < 0)) {
+            throw new StatusError(`The field "download_from_timestamp" must be a positive number.`, 400);
+        }
+
+        // A collect in progress holds its own copy of the secret and commits it when it
+        // ends, which would silently overwrite the update
+        if (CollectPool.getInstance().get(credential.id) != undefined) {
+            throw new StatusError(`A collect is already in progress for credential with id "${id}".`, 409);
+        }
+
+        // Get collector from id
+        const collector = await CollectorLoader.get(credential.collector_id);
+
+        // Get customer from user
+        const customer = await user.getCustomer();
+
+        // Update collector params based on customer settings
+        AbstractCollector.updateCollectorParams(customer.authenticationMethod, collector.config);
+
+        // Update params if provided
+        if (params != undefined) {
+            // Update credential note
+            if (params.note != undefined) {
+                credential.note = params.note;
+            }
+            delete params.note;
+
+            // Check if all mandatory params are present
+            const missing_params = Object.keys(collector.config.params)
+                .filter((param) => collector.config.params[param].mandatory && (!params.hasOwnProperty(param) || !params[param]));
+            if(missing_params.length > 0) {
+                throw new MissingParams(missing_params);
+            }
+
+            const secret = credential.getSecret();
+
+            // Load the stored secret before updating it, otherwise committing would drop
+            // the cookies and the local storage
+            await secret.getParams();
+            await secret.setParams(params);
+
+            // Update secret in Secure Storage
+            await secret.commit();
+        }
+
+        // Update download_from_timestamp if provided
+        if (download_from_timestamp != undefined) {
+            credential.download_from_timestamp = download_from_timestamp;
+        }
+
+        // Compute next collect
+        credential.computeNextCollect(customer.maxDelayBetweenCollect);
+
+        // Update credential in database
+        await credential.commit();
+
+        // Start web socket server and get token
+        const webSocketServer = new WebSocketServer(this.httpServer, user.locale, collector);
+        const wsPath = webSocketServer.start();
+
+        // Start collect
+        const collect = new Collect(credential.id, webSocketServer)
+
+        // Register collect in progress
+        CollectPool.getInstance().registerCollect(credential.id, collect);
+
+        // Do not wait for promise to resolve
+        collect.start().catch((err) => {
+            console.error(`Collect for credential ${credential.id} has failed`);
+            console.error(err);
+        })
+        .finally(() => {
+            // Unregister collect in progress
+            CollectPool.getInstance().unregisterCollect(credential.id);
+            // Close web socket server
+            webSocketServer.close();
+        });
+
+        // Return credential
+        return {
+            id: credential.id,
+            user_id: credential.user_id,
+            note: credential.note,
+            create_timestamp: credential.create_timestamp,
+            download_from_timestamp: credential.download_from_timestamp,
+            last_collect_timestamp: credential.last_collect_timestamp,
+            next_collect_timestamp: credential.next_collect_timestamp,
+            invoices: credential.invoices,
+            state: credential.state,
+            collector: collector.config,
+            wsPath: wsPath
+        };
+    }
+
+    // TOKEN AUTHENTICATION
     public async delete_credential(
         bearer: string | undefined,
         user_id: string,

--- a/views/openapi/openapi.yml
+++ b/views/openapi/openapi.yml
@@ -1578,6 +1578,80 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/error"
+    put:
+      tags:
+        - Credential
+      summary: Update credential (Bearer)
+      description: Updates a credential and starts collection. Only the provided
+        fields are updated.
+      security:
+        - CustomerBearerAuth: []
+        - UserBearerAuth: []
+        - TokenAuth: []
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/userId"
+        - name: credentialId
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/credentialId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  allOf:
+                    - $ref: "#/components/schemas/credentialParams"
+                  description: Replaces the stored parameters. _The cookies and the local storage
+                    are kept._
+                download_from_timestamp:
+                  allOf:
+                    - $ref: "#/components/schemas/downloadFromTimestamp"
+                  description: Timestamp to start downloading invoices from in ms.
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/credential"
+        "400":
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+        "401":
+          description: Authentication error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+        "403":
+          description: Credential does not belong to user
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+        "409":
+          description: A collect is already in progress for this credential
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
     delete:
       tags:
         - Credential


### PR DESCRIPTION
## Problem

A credential can only be created and deleted. There is no way to rotate a password after the supplier forced a change, nor to widen `download_from_timestamp` once the credential exists.

The only workaround is to delete the credential and create it again, which drops the collected invoices history stored on it. That history is what prevents invoices from being sent twice to the integrations, and what `computeNextCollect()` uses to schedule the next collection.

## What the endpoint does

`PUT /user/{userId}/credential/{credentialId}` updates the provided fields only, following the convention of `PUT /callback/{callbackId}`:

- `params` replaces the stored parameters, `params.note` still feeding the credential note like on creation
- `download_from_timestamp` moves the download window

A collection is then started, exactly like the creation endpoint does, and the response carries the same shape including `wsPath`. A password change on a collector that needs an interactive login can therefore be completed straight away, and widening the window collects in one call rather than two.

Three decisions worth reviewing:

- **The cookies and the local storage are kept.** A still valid session keeps working after a password change, and a dead one falls back to the login with the new parameters. Wiping them would force a pointless re-login on every edit.
- **Updating is refused with a 409 while a collect is in progress.** The running collect holds its own copy of the secret and commits it when it ends, so the update would be silently overwritten. 409 is the only code in this range the project does not already use, happy to switch it to 400 for consistency.
- **No deprecated token-only variant was added.** The endpoint is only exposed under `/user/{userId}/...`, since the `/credential/{credentialId}` shape exists for backwards compatibility.

## Note on `download_from_timestamp`

Lowering `download_from_timestamp` through this endpoint has no visible effect on its own, because invoices listed but not downloaded stay excluded from every later collect. That is fixed separately in #548, and the two together are what make the setting actually editable.

## Testing

- `npx tsc --noEmit` passes.
- `npm run test.cicd.collectors` passes, 9072 collectors loaded.
- `views/openapi/openapi.yml` regenerated with `npm run build.openapi` and committed, `swagger-cli validate` passes.
