### PR TITLE
Modernize the UI: focus visibility, contrast and fluid layout

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -9211,6 +9211,7 @@
   "i18n.views.manage.cant_find_collector": "Can't find a collector?",
   "i18n.views.manage.close": "Close",
   "i18n.views.manage.collecting_data": "Collecting data...",
+  "i18n.views.manage.configure": "Configure",
   "i18n.views.manage.connect_account": "Connect your account to start collecting invoices",
   "i18n.views.manage.continue": "Continue",
   "i18n.views.manage.date_placeholder": "dd / mm / yyyy",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -9211,6 +9211,7 @@
   "i18n.views.manage.cant_find_collector": "Collecteur introuvable ?",
   "i18n.views.manage.close": "Fermer",
   "i18n.views.manage.collecting_data": "Collecte des données...",
+  "i18n.views.manage.configure": "Configurer",
   "i18n.views.manage.connect_account": "Connectez votre compte pour commencer à collecter les factures",
   "i18n.views.manage.continue": "Continuer",
   "i18n.views.manage.date_placeholder": "jj / mm / aaaa",

--- a/views/styles/theme.dark.css
+++ b/views/styles/theme.dark.css
@@ -14,7 +14,7 @@
   /* Background & Text */
   --bg: #ffffff;
   --text: #050505;
-  --text-secondary: #050505;
+  --text-secondary: #4a4a4a;
   --muted: #6c6c6c;
   --placeholder: #a0a0a0;
 
@@ -151,8 +151,20 @@ body {
 }
 
 .ic-header {
+  /* Le bouton retour etait pose a cote du titre par un flex en ligne, ce qui
+     le laissait flotter dans la marge sans alignement avec le contenu. Il est
+     desormais empile au-dessus. */
   display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
   margin-bottom: 2rem;
+  /* Meme colonne que .ic-search-bar et .ic-grid : sans cela le titre est cale
+     sur le bord du conteneur tandis que le contenu est centre. */
+  width: 100%;
+  max-width: 56rem;
+  margin-left: auto;
+  margin-right: auto;
   padding-bottom: 20px;
   border-bottom: 1px solid rgba(0, 0, 0, .1);
 }
@@ -190,27 +202,12 @@ body {
   display: grid;
   gap: 1.5rem;
   max-width: 56rem;
-  grid-template-columns: 1fr;
+  /* Les colonnes suivent la largeur reelle plutot que des paliers fixes : le
+     widget est souvent embarque dans une iframe etroite, dont la largeur n'a
+     aucun rapport avec celle de la fenetre interrogee par une media query. */
+  grid-template-columns: repeat(auto-fill, minmax(15rem, 1fr));
   margin-left: auto;
   margin-right: auto;
-}
-
-@media (min-width: 500px) {
-  .ic-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-@media (min-width: 750px) {
-  .ic-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-}
-
-@media (min-width: 1000px) {
-  .ic-grid {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-  }
 }
 
 /* ===================================
@@ -563,6 +560,57 @@ body {
   outline: none;
   border-color: var(--primary);
   box-shadow: 0 0 0 3px var(--primary-focus);
+}
+
+/* ===================================
+   FOCUS VISIBILITY & MOTION
+   =================================== */
+
+/* Tout element atteignable au clavier doit montrer ou se trouve le focus.
+   L'anneau est dessine avec outline plutot qu'avec box-shadow pour rester
+   visible dans les modes de contraste forces. */
+.ic-button:focus-visible,
+.ic-card:focus-visible,
+.ic-back-button:focus-visible,
+.ic-input:focus-visible,
+.ic-textarea:focus-visible,
+.ic-datepicker-input:focus-visible,
+.ic-datepicker-day:focus-visible,
+.ic-datepicker-nav-button:focus-visible,
+.ic-datepicker-footer-button:focus-visible,
+.ic-datepicker-month-year-select select:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+/* La souris ne doit pas declencher l'anneau. */
+.ic-button:focus:not(:focus-visible),
+.ic-card:focus:not(:focus-visible),
+.ic-back-button:focus:not(:focus-visible) {
+  outline: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* ===================================
+   TOUCH TARGETS
+   =================================== */
+
+/* 44px est la cible tactile minimale recommandee. */
+.ic-button,
+.ic-input,
+.ic-textarea,
+.ic-datepicker-input {
+  min-height: 2.75rem;
 }
 
 .ic-input::placeholder,

--- a/views/styles/theme.default.css
+++ b/views/styles/theme.default.css
@@ -42,7 +42,7 @@
   --warning: #fdd835;        /* yellow-600 */
   --warning-hover: #fbc02d;  /* yellow-700 */
   --warning-bg: #fff9c4;     /* yellow-100 */
-  --warning-text: #f9a825;   /* yellow-800 */
+  --warning-text: #854d0e;   /* yellow-800 */
 
   /* Status - Danger */
   --danger: #dc2626;         /* red-600 */
@@ -133,8 +133,20 @@ body {
 }
 
 .ic-header {
+  /* Le bouton retour etait pose a cote du titre par un flex en ligne, ce qui
+     le laissait flotter dans la marge sans alignement avec le contenu. Il est
+     desormais empile au-dessus. */
   display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
   margin-bottom: 2rem;
+  /* Meme colonne que .ic-search-bar et .ic-grid : sans cela le titre est cale
+     sur le bord du conteneur tandis que le contenu est centre. */
+  width: 100%;
+  max-width: 56rem;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .ic-header-title {
@@ -169,21 +181,12 @@ body {
   display: grid;
   gap: 1.5rem;
   max-width: 56rem;
-  grid-template-columns: 1fr;
+  /* Les colonnes suivent la largeur reelle plutot que des paliers fixes : le
+     widget est souvent embarque dans une iframe etroite, dont la largeur n'a
+     aucun rapport avec celle de la fenetre interrogee par une media query. */
+  grid-template-columns: repeat(auto-fill, minmax(15rem, 1fr));
   margin-left: auto;
   margin-right: auto;
-}
-
-@media (min-width: 500px) {
-  .ic-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-@media (min-width: 750px) {
-  .ic-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
 }
 
 /* ===================================
@@ -509,6 +512,57 @@ body {
   outline: none;
   border-color: var(--primary-hover);
   box-shadow: 0 0 0 2px var(--primary-focus);
+}
+
+/* ===================================
+   FOCUS VISIBILITY & MOTION
+   =================================== */
+
+/* Tout element atteignable au clavier doit montrer ou se trouve le focus.
+   L'anneau est dessine avec outline plutot qu'avec box-shadow pour rester
+   visible dans les modes de contraste forces. */
+.ic-button:focus-visible,
+.ic-card:focus-visible,
+.ic-back-button:focus-visible,
+.ic-input:focus-visible,
+.ic-textarea:focus-visible,
+.ic-datepicker-input:focus-visible,
+.ic-datepicker-day:focus-visible,
+.ic-datepicker-nav-button:focus-visible,
+.ic-datepicker-footer-button:focus-visible,
+.ic-datepicker-month-year-select select:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+/* La souris ne doit pas declencher l'anneau. */
+.ic-button:focus:not(:focus-visible),
+.ic-card:focus:not(:focus-visible),
+.ic-back-button:focus:not(:focus-visible) {
+  outline: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* ===================================
+   TOUCH TARGETS
+   =================================== */
+
+/* 44px est la cible tactile minimale recommandee. */
+.ic-button,
+.ic-input,
+.ic-textarea,
+.ic-datepicker-input {
+  min-height: 2.75rem;
 }
 
 .ic-input::placeholder,

--- a/views/styles/theme.ocean.css
+++ b/views/styles/theme.ocean.css
@@ -17,7 +17,7 @@
   /* Background & Text */
   --bg: #ffffff;
   --text: #333333;
-  --text-secondary: #333333;
+  --text-secondary: #5b6472;
   --muted: #666666;
   --placeholder: #999999;
 
@@ -38,7 +38,7 @@
 
   /* Cards */
   --card: #ffffff;
-  --card-border: #00f;
+  --card-border: #d6e0ec;
   --card-border-default: rgba(0, 0, 0, 0.2);
   --card-special: rgba(208, 235, 253, 0.1);
   --card-special-hover: rgba(208, 235, 253, 0.2);
@@ -155,8 +155,20 @@ body {
 }
 
 .ic-header {
+  /* Le bouton retour etait pose a cote du titre par un flex en ligne, ce qui
+     le laissait flotter dans la marge sans alignement avec le contenu. Il est
+     desormais empile au-dessus. */
   display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
   margin-bottom: 2rem;
+  /* Meme colonne que .ic-search-bar et .ic-grid : sans cela le titre est cale
+     sur le bord du conteneur tandis que le contenu est centre. */
+  width: 100%;
+  max-width: 56rem;
+  margin-left: auto;
+  margin-right: auto;
   padding-bottom: 20px;
   border-bottom: 1px solid rgba(0, 0, 0, .1);
 }
@@ -194,27 +206,12 @@ body {
   display: grid;
   gap: 1.5rem;
   max-width: 56rem;
-  grid-template-columns: 1fr;
+  /* Les colonnes suivent la largeur reelle plutot que des paliers fixes : le
+     widget est souvent embarque dans une iframe etroite, dont la largeur n'a
+     aucun rapport avec celle de la fenetre interrogee par une media query. */
+  grid-template-columns: repeat(auto-fill, minmax(15rem, 1fr));
   margin-left: auto;
   margin-right: auto;
-}
-
-@media (min-width: 500px) {
-  .ic-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-@media (min-width: 750px) {
-  .ic-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-}
-
-@media (min-width: 1000px) {
-  .ic-grid {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-  }
 }
 
 /* ===================================
@@ -570,6 +567,57 @@ body {
   outline: none;
   border-color: var(--primary);
   box-shadow: 0 0 0 3px var(--primary-focus);
+}
+
+/* ===================================
+   FOCUS VISIBILITY & MOTION
+   =================================== */
+
+/* Tout element atteignable au clavier doit montrer ou se trouve le focus.
+   L'anneau est dessine avec outline plutot qu'avec box-shadow pour rester
+   visible dans les modes de contraste forces. */
+.ic-button:focus-visible,
+.ic-card:focus-visible,
+.ic-back-button:focus-visible,
+.ic-input:focus-visible,
+.ic-textarea:focus-visible,
+.ic-datepicker-input:focus-visible,
+.ic-datepicker-day:focus-visible,
+.ic-datepicker-nav-button:focus-visible,
+.ic-datepicker-footer-button:focus-visible,
+.ic-datepicker-month-year-select select:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+/* La souris ne doit pas declencher l'anneau. */
+.ic-button:focus:not(:focus-visible),
+.ic-card:focus:not(:focus-visible),
+.ic-back-button:focus:not(:focus-visible) {
+  outline: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* ===================================
+   TOUCH TARGETS
+   =================================== */
+
+/* 44px est la cible tactile minimale recommandee. */
+.ic-button,
+.ic-input,
+.ic-textarea,
+.ic-datepicker-input {
+  min-height: 2.75rem;
 }
 
 .ic-input::placeholder,

--- a/views/ui/script.js
+++ b/views/ui/script.js
@@ -251,7 +251,7 @@ function showForm(company) {
     document.getElementById('form-logo').src = company.logo;
     document.getElementById('form-name').textContent = company.name;
     document.getElementById('form-description').textContent = company.description;
-    document.getElementById('form-title').textContent = `Configure ${company.name}`;
+    document.getElementById('form-title').textContent = `${i18n.configure} ${company.name}`;
     
     const badge = document.getElementById('form-badge');
     if (company.state === 'planned') {

--- a/views/ui/ui.ejs
+++ b/views/ui/ui.ejs
@@ -388,6 +388,9 @@
             letUsKnow: "<%= __('i18n.views.manage.let_us_know') %>",
             requestNew: "<%= __('i18n.views.manage.request_new') %>",
             
+            // Form
+            configure: "<%= __('i18n.views.manage.configure') %>",
+
             // Form validation
             fieldsRequired: "<%= __('i18n.views.manage.fields_required') %>",
             fieldRequired: "<%= __('i18n.views.manage.field_required') %>",


### PR DESCRIPTION
## Accessibility

**Focus is invisible.** `.ic-input:focus` and the datepicker select set `outline: none`, and nothing replaces it anywhere in the three themes. A keyboard user has no way of knowing where they are, which fails WCAG 2.4.7. Every focusable element now draws a ring on `:focus-visible`, using `outline` rather than `box-shadow` so it survives forced colors mode, and `:focus:not(:focus-visible)` keeps the mouse from triggering it.

**No motion preference.** The stylesheets carry fifteen transitions and no `prefers-reduced-motion` block. One is added.

**Touch targets.** Buttons and inputs get the 44px minimum.

## Color defects

| Theme | Token | Before | After |
|---|---|---|---|
| default | `--warning-text` | `#f9a825`, **1.84:1** on `--warning-bg` | `#854d0e`, 6.39:1 |
| ocean | `--card-border` | `#00f` | `#d6e0ec` |
| ocean | `--text-secondary` | `#333333`, equal to `--text` | `#5b6472` |
| dark | `--text-secondary` | `#050505`, equal to `--text` | `#4a4a4a` |

`--warning-text` is commented `/* yellow-800 */` but holds a yellow-600, which is why the ratio collapses. `#00f` is a pure blue outlining every card, visibly a leftover. `--text-secondary` equal to `--text` flattens the entire secondary hierarchy: descriptions, meta lines and subtitles all render as primary text.

All three themes now clear AA on the six text-on-background pairs.

## Layout

**The grid stepped through breakpoints on the window width**, which this UI does not control: it is embedded in an iframe whose width is unrelated to the window's. A narrow iframe in a wide window got three columns. It now fills with `repeat(auto-fill, minmax(15rem, 1fr))`, which reacts to the space it actually has.

**The header laid the back button beside the title with a row flex**, leaving it floating in the margin, vertically centred against a two-line block. It is now stacked above the title. The header also takes the column width already used by `.ic-search-bar` and `.ic-grid`, so the title, the search field and the cards finally share one left edge — before, the title sat on the container padding while everything below it was centred on a narrower column.

## One string

`Configure ${company.name}` in `showForm()` was the last hardcoded English string in an otherwise fully translated UI. It moves to `i18n.views.manage.configure`.

## A question rather than a change

`theme.dark.css` describes itself as *"Clean dark theme with black accents"* but its palette is `--bg: #ffffff`, `--text: #050505`, `--card: #ffffff`. It is a white theme with black accents, not a dark one. I left it alone: whether the name or the palette is wrong is your call, and flipping it would change the interface for everyone who selected that theme. Happy to send a real dark palette if you want one — note that `.ic-card-logo` inherits `background: var(--bg)`, so collector logos drawn for a white background would need a white plate.

## Testing

- `npm run test.cicd.locales` passes on the same 5 tests as `master`, the new key present in both locales and in alphabetical order.
- `node --check views/ui/script.js` passes.
- Contrast ratios computed on the six text-on-background pairs of each theme, translucent backgrounds flattened over `--bg` first.
- Rendered in Chrome at 1100px against a live instance: collectors list, connectors panel and credential form.
